### PR TITLE
Add Mermaid diagram support

### DIFF
--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,4 @@
+<pre class="mermaid">
+  {{- .Inner | htmlEscape | safeHTML }}
+</pre>
+{{ .Page.Store.Set "hasMermaid" true }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,3 +14,11 @@
 </p>
 <br>
 Copyright © Stein-Otto Svorstøl · {{ now.Year }}
+
+{{ if .Page.Store.Get "hasMermaid" }}
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  mermaid.initialize({ startOnLoad: true, theme: dark ? 'dark' : 'default' });
+</script>
+{{ end }}


### PR DESCRIPTION
## Summary

The site had no Mermaid support — a ` ```mermaid ` fenced block rendered as plain text. This adds rendering using Hugo's idiomatic codeblock render hook, so you can author diagrams with a normal fence and they render as charts.

- **`layouts/_default/_markup/render-codeblock-mermaid.html`** (new): Goldmark codeblock render hook that emits `<pre class="mermaid">` for ` ```mermaid ` fences and flags the page via `.Page.Store`.
- **`layouts/partials/footer.html`**: conditional loader that imports the Mermaid CDN module **only on pages that contain a diagram**. Pinned to `mermaid@11`. Picks `dark`/`default` theme from `prefers-color-scheme` to match BearCub's auto dark mode.

## Test plan

> Note: Hugo isn't installed in the build environment and the theme submodule isn't checked out, so this wasn't previewed locally. Verify before merging:

- [ ] Add a post with a ` ```mermaid ` fence (e.g. `graph TD; A-->B;`), run `hugo server`, confirm a diagram renders (not raw text).
- [ ] Confirm the loader `<script>` is absent on pages without a diagram (view source on homepage / a plain post).
- [ ] Toggle OS dark mode + reload; confirm diagram theme matches the background.

## Out of scope

- Live theme re-render on OS dark/light toggle without a reload.
- Self-hosting the Mermaid JS (uses pinned CDN, consistent with the existing Bluesky shortcode).

https://claude.ai/code/session_01PzpmH2KgQ6LBYqqM54DZcb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzpmH2KgQ6LBYqqM54DZcb)_